### PR TITLE
Fix CCR monthly payment tax

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -82,8 +82,10 @@ def run_ccr_balancing_loop(target_das, msrp, lease_cash, residual_value, term_mo
         monthly_rent_charge = (adj_cap_cost_loop + residual_value) * mf
         base_payment_loop = round(monthly_depreciation + monthly_rent_charge, 2)
 
-        monthly_tax_loop = round(base_payment_loop * county_tax, 2)
-        first_payment_loop = round(base_payment_loop + monthly_tax_loop + monthly_ltr_fee, 2)
+        # Monthly payment should include the LTR fee before tax is applied
+        monthly_payment_pre_tax = base_payment_loop + monthly_ltr_fee
+        monthly_tax_loop = round(monthly_payment_pre_tax * county_tax, 2)
+        first_payment_loop = round(monthly_payment_pre_tax + monthly_tax_loop, 2)
 
         ccr_tax_loop = round(ccr_guess * county_tax, 2)
 


### PR DESCRIPTION
## Summary
- fix tax calculation so monthly fee is taxed before computing the first payment

## Testing
- `python -m py_compile lease_app.py`
- `python - <<'EOF'
from lease_app import run_ccr_balancing_loop
result = run_ccr_balancing_loop(target_das=2000, msrp=30000, lease_cash=0, residual_value=15000, term_months=36, mf=0.002, county_tax=0.07, q_value=62.50)
print(result)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684c6ba7a35083318e7898551bfe65a2