### PR TITLE
Fix debug output in lease_app

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -171,7 +171,7 @@ if st.session_state.page == "main":
                             st.write(f"**Money Factor (adjusted):** {mf_to_use_adjusted:.5f}")
                             st.write(f"**Residual Percentage:** {residual_percent:.0%}")
                             st.write(f"**Monthly Payment:** ${payment_calc['Monthly Payment']:,.2f}")
-                           >                            st.write(f"**Total Advance (TA):** ${payment_calc['Total Advance']:,.2f}")
+                            st.write(f"**Total Advance (TA):** ${payment_calc['Total Advance']:,.2f}")
                             st.write(f"**Base Payment:** ${payment_calc['Base Payment']:,.2f}")
                             st.write(f"**Residual Value:** ${residual_value:,.2f}")
                         else:


### PR DESCRIPTION
## Summary
- remove stray `>` from the debug display for total advance in `lease_app.py`

## Testing
- `python -m py_compile lease_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68519b2434d48331bd68908c9009af4a