### PR TITLE
Restore setting page module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Lease Quote Application
+
+This repository contains a Streamlit application for calculating vehicle lease quotes.
+
+## Running the app
+
+Install the required packages from `requirements.txt` and launch Streamlit:
+
+```bash
+pip install -r requirements.txt
+streamlit run lease_app.py
+```
+
+## Adjusting settings
+
+Application settings such as default tax county and tier are managed in
+`setting_page.py`. Click the **Settings** button in the app to open this page.
+The sidebar provides options to change values and a **Reset to Defaults** button
+that restores the original configuration.

--- a/lease_app.py
+++ b/lease_app.py
@@ -216,48 +216,11 @@ if st.session_state.page == "main":
         st.session_state.page = "settings"
 
 elif st.session_state.page == "settings":
-    st.subheader("Settings")
+    # Display settings page using the dedicated module
+    import setting_page
 
-    # Temporary variables for settings
-    temp_settings = st.session_state.settings.copy()
+    setting_page.show_settings()
 
-    counties = county_rates[county_column].tolist()
-    temp_settings["default_county"] = st.selectbox(
-        "Default Tax County",
-        counties,
-        index=counties.index(st.session_state.settings["default_county"]) if st.session_state.settings["default_county"] in counties else 0
-    )
-
-    tiers = ["Tier 1", "Tier 2", "Tier 3", "Tier 4", "Tier 5"]
-    temp_settings["default_tier"] = st.selectbox(
-        "Default Tier",
-        tiers,
-        index=tiers.index(st.session_state.settings["default_tier"])
-    )
-
-    temp_settings["default_apply_rebates"] = st.checkbox(
-        "Default Apply Rebates",
-        value=st.session_state.settings["default_apply_rebates"]
-    )
-
-    temp_settings["auto_apply_lease_cash"] = st.checkbox(
-        "Auto-apply Lease Cash",
-        value=st.session_state.settings["auto_apply_lease_cash"]
-    )
-
-    temp_settings["money_factor_markup"] = st.number_input(
-        "Money Factor Markup",
-        min_value=0.0,
-        value=st.session_state.settings["money_factor_markup"],
-        step=0.0001
-    )
-
-    temp_settings["enable_debug"] = st.checkbox(
-        "Enable Debug Display",
-        value=st.session_state.settings["enable_debug"]
-    )
-
-    # Save and Return button
-    if st.button("Save and Return"):
-        st.session_state.settings = temp_settings
+    # Button to return to the main page
+    if st.button("Return"):
         st.session_state.page = "main"

--- a/setting_page.py
+++ b/setting_page.py
@@ -1,79 +1,85 @@
 import streamlit as st
 
-# Initialize session state for settings if not already present
-if 'settings' not in st.session_state:
-    st.session_state.settings = {
-        "default_county": "Adams",
-        "default_tier": "Tier 1",
-        "auto_apply_lease_cash": False,
-        "money_factor_markup": 0.0,
-        "enable_debug": False
-    }
 
-# Sidebar for settings page
-st.sidebar.title("Settings")
+def show_settings() -> None:
+    """Display the settings sidebar and handle reset functionality."""
 
-# Tax County dropdown
-counties = ["Adams", "Boulder", "Denver"]  # Replace with your actual list
-default_county = st.sidebar.selectbox(
-    "Default Tax County",
-    counties,
-    index=counties.index(st.session_state.settings["default_county"]),
-    help="Select the default county for tax calculations."
-)
+    # Initialize session state for settings if not already present
+    if "settings" not in st.session_state:
+        st.session_state.settings = {
+            "default_county": "Adams",
+            "default_tier": "Tier 1",
+            "auto_apply_lease_cash": False,
+            "money_factor_markup": 0.0,
+            "enable_debug": False,
+        }
 
-# Tier dropdown
-tiers = ["Tier 1", "Tier 2", "Tier 3", "Tier 4", "Tier 5"]
-default_tier = st.sidebar.selectbox(
-    "Default Tier",
-    tiers,
-    index=tiers.index(st.session_state.settings["default_tier"]),
-    help="Select the default tier for lease calculations."
-)
+    # Sidebar for settings page
+    st.sidebar.title("Settings")
 
-# Auto-apply lease cash checkbox
-auto_apply_lease_cash = st.sidebar.checkbox(
-    "Auto-apply Lease Cash",
-    value=st.session_state.settings["auto_apply_lease_cash"],
-    help="If checked, lease cash will be automatically applied."
-)
+    # Tax County dropdown
+    counties = ["Adams", "Boulder", "Denver"]  # Replace with your actual list
+    default_county = st.sidebar.selectbox(
+        "Default Tax County",
+        counties,
+        index=counties.index(st.session_state.settings["default_county"]),
+        help="Select the default county for tax calculations.",
+    )
 
-# Money Factor Markup input
-money_factor_markup = st.sidebar.number_input(
-    "Money Factor Markup",
-    min_value=0.0,
-    max_value=0.1,
-    value=st.session_state.settings["money_factor_markup"],
-    step=0.0001,
-    help="Add a markup to the base money factor (e.g., 0.001 increases the rate)."
-)
+    # Tier dropdown
+    tiers = ["Tier 1", "Tier 2", "Tier 3", "Tier 4", "Tier 5"]
+    default_tier = st.sidebar.selectbox(
+        "Default Tier",
+        tiers,
+        index=tiers.index(st.session_state.settings["default_tier"]),
+        help="Select the default tier for lease calculations.",
+    )
 
-# Enable Debug Display checkbox
-enable_debug = st.sidebar.checkbox(
-    "Enable Debug Display",
-    value=st.session_state.settings["enable_debug"],
-    help="If checked, additional debug information will be displayed."
-)
+    # Auto-apply lease cash checkbox
+    auto_apply_lease_cash = st.sidebar.checkbox(
+        "Auto-apply Lease Cash",
+        value=st.session_state.settings["auto_apply_lease_cash"],
+        help="If checked, lease cash will be automatically applied.",
+    )
 
-# Save settings to session state
-st.session_state.settings.update({
-    "default_county": default_county,
-    "default_tier": default_tier,
-    "auto_apply_lease_cash": auto_apply_lease_cash,
-    "money_factor_markup": money_factor_markup,
-    "enable_debug": enable_debug
-})
+    # Money Factor Markup input
+    money_factor_markup = st.sidebar.number_input(
+        "Money Factor Markup",
+        min_value=0.0,
+        max_value=0.1,
+        value=st.session_state.settings["money_factor_markup"],
+        step=0.0001,
+        help="Add a markup to the base money factor (e.g., 0.001 increases the rate).",
+    )
 
-# Reset to defaults button
-if st.sidebar.button("Reset to Defaults"):
-    st.session_state.settings = {
-        "default_county": "Adams",
-        "default_tier": "Tier 1",
-        "auto_apply_lease_cash": False,
-        "money_factor_markup": 0.0,
-        "enable_debug": False
-    }
-    st.experimental_rerun()
+    # Enable Debug Display checkbox
+    enable_debug = st.sidebar.checkbox(
+        "Enable Debug Display",
+        value=st.session_state.settings["enable_debug"],
+        help="If checked, additional debug information will be displayed.",
+    )
+
+    # Save settings to session state
+    st.session_state.settings.update(
+        {
+            "default_county": default_county,
+            "default_tier": default_tier,
+            "auto_apply_lease_cash": auto_apply_lease_cash,
+            "money_factor_markup": money_factor_markup,
+            "enable_debug": enable_debug,
+        }
+    )
+
+    # Reset to defaults button
+    if st.sidebar.button("Reset to Defaults"):
+        st.session_state.settings = {
+            "default_county": "Adams",
+            "default_tier": "Tier 1",
+            "auto_apply_lease_cash": False,
+            "money_factor_markup": 0.0,
+            "enable_debug": False,
+        }
+        st.experimental_rerun()
 
 # Example main app integration (uncomment and adapt as needed)
 """


### PR DESCRIPTION
## Summary
- restore `setting_page.py` with sidebar reset logic
- call `show_settings()` from `lease_app.py`
- document settings page usage in README
- verify modules compile

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68519d1b5e7483319510a700ee4543ae