### PR TITLE
Refactor default settings

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -1,7 +1,7 @@
 import streamlit as st
 st.write("🔥 Loaded lease_app.py v2 at", __file__)
 import streamlit as st
-from setting_page import show_settings
+from setting_page import show_settings, DEFAULT_SETTINGS
 from lease_calculations import calculate_payment
 
 def show_quote_page():
@@ -52,8 +52,8 @@ def show_quote_page():
 
 def main():
     # initialize settings on first run
-    if "settings" not in st.session_state:
-        st.session_state.settings = {}
+    if "settings" not in st.session_state or not st.session_state.settings:
+        st.session_state.settings = DEFAULT_SETTINGS.copy()
     # sidebar navigation
     st.sidebar.title("Main Menu")
     page = st.sidebar.radio("Go to", ["Quote", "Settings"])

--- a/setting_page.py
+++ b/setting_page.py
@@ -1,33 +1,43 @@
 import streamlit as st
 
+# default values used across the application
+DEFAULT_SETTINGS = {
+    "default_county": "Adams",
+    "counties": [
+        "Adams",
+        "Allen",
+        "Ashland",
+        "Ashtabula",
+        "Athens",
+        # …and all your counties
+    ],
+    "tax_rates": {
+        "Adams": 7.25,
+        "Allen": 6.85,
+        "Ashland": 7.00,
+        # …
+    },
+    "money_factors": {
+        # (term, mileage): base money factor
+        (36, 10000): 0.00256,
+        (36, 12000): 0.00275,
+        # …
+    },
+    "residuals": {
+        (36, 10000): 60,  # percent
+        (36, 12000): 58,  # percent
+        # …
+    },
+    "money_factor_markup": 0.0000,
+}
+
+
 def show_settings() -> None:
     """Display the settings sidebar and handle reset functionality."""
-    # default values
-    defaults = {
-        "default_county": "Adams",
-        "counties": [
-            "Adams", "Allen", "Ashland", "Ashtabula", "Athens", # …and all your counties
-        ],
-        "tax_rates": {
-            "Adams": 7.25, "Allen": 6.85, "Ashland": 7.00, # …
-        },
-        "money_factors": {
-            # (term, mileage): base money factor
-            (36, 10000): 0.00256,
-            (36, 12000): 0.00275,
-            # …
-        },
-        "residuals": {
-            (36, 10000): 60,    # percent
-            (36, 12000): 58,    # percent
-            # …
-        },
-        "money_factor_markup": 0.0000,
-    }
 
     # Initialize session state for settings if not already present
     if "settings" not in st.session_state or not st.session_state.settings:
-        st.session_state.settings = defaults.copy()
+        st.session_state.settings = DEFAULT_SETTINGS.copy()
 
     st.header("⚙️ Settings")
     s = st.session_state.settings
@@ -44,5 +54,5 @@ def show_settings() -> None:
 
     st.markdown("---")
     if st.button("Reset to Defaults"):
-        st.session_state.settings = {}
+        st.session_state.settings = DEFAULT_SETTINGS.copy()
         st.experimental_rerun()


### PR DESCRIPTION
## Summary
- extract `DEFAULT_SETTINGS` constant to share between modules
- use `DEFAULT_SETTINGS` to initialize session settings in the app

## Testing
- `python -m py_compile lease_app.py setting_page.py lease_calculations.py`

------
https://chatgpt.com/codex/tasks/task_e_6851bb32f2f08331ba1d58d59e3b2076