### PR TITLE
Fix expander state

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -148,7 +148,7 @@ if vin_input:
                         except:
                             title = "Monthly Payment (w/ tax): —"
 
-                        with st.expander(title, key=f"expander_{term}_{mileage}"):
+                        with st.expander(title):
                             st.number_input("Selling Price ($)", value=selling_price, step=100.0, key=f"selling_price_{term}_{mileage}", disabled=True)
                             st.toggle("Apply MF Markup (+0.00040)", value=apply_markup, key=f"mf_markup_{term}_{mileage}", disabled=True)
                             st.toggle("Apply Lease Cash", value=apply_cash, key=f"apply_cash_{term}_{mileage}", disabled=True)


### PR DESCRIPTION
## Summary
- remove redundant key from expander in `lease_app.py`

## Testing
- `pip install -r requirements.txt`
- `streamlit run lease_app.py` *(fails to detect external IP but app runs)*

------
https://chatgpt.com/codex/tasks/task_e_685227a44aec8331903ef8eab18d0f94