### PR TITLE
Fix expander usage

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -56,7 +56,7 @@ try:
 except:
     title = "Monthly Payment"
 
-with st.expander(title, key=f"expander_{term}_{mileage}"):
+with st.expander(title):
     st.markdown(f"""
     <div class="lease-details">
         <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 2rem;">


### PR DESCRIPTION
## Summary
- remove unused key argument from Streamlit expander

## Testing
- `pip install -r requirements.txt`
- `timeout 15 streamlit run lease_app.py --server.headless true --server.port 8502`

------
https://chatgpt.com/codex/tasks/task_e_685244d038c08331b10d03845bdd9992