### PR TITLE
Fix dataset column references in lease app

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -47,7 +47,7 @@ if vin_input and model_number:
         st.error("No lease program found for this model number.")
     else:
         lease_info = lease_matches.iloc[0]
-        model_year = lease_info.get("ModelYear", model_year if manual_entry else "N/A")
+        model_year = lease_info.get("Year", model_year if manual_entry else "N/A")
         make = lease_info.get("Make", make if manual_entry else "N/A")
         model = lease_info.get("Model", model if manual_entry else "N/A")
         trim = lease_info.get("Trim", trim if manual_entry else "N/A")
@@ -61,7 +61,7 @@ if vin_input and model_number:
         lease_terms = sorted(lease_matches["Term"].dropna().unique())
 
         for term in lease_terms:
-            term_group = lease_matches[lease_matches["LeaseTerm"] == term]
+            term_group = lease_matches[lease_matches["Term"] == term]
             st.subheader(f"{term}-Month Lease")
 
             for mileage in mileage_options:


### PR DESCRIPTION
## Summary
- fix `Year` lookup for vehicles instead of `ModelYear`
- use correct `Term` column when filtering lease programs

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`
- `streamlit run lease_app.py` *(fails: Did not auto detect external IP, but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_685430e79d848331a3e93a17808696b8