### PR TITLE
Apply lease cash and display make

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -36,7 +36,9 @@ if vin_input:
         else:
             lease_info = lease_matches.iloc[0]
             model_year = lease_info.get("Year", "N/A")
-            make = lease_info.get("Make", "N/A")
+            # The lease programs file does not include a Make column. All data
+            # currently corresponds to Hyundai, so use that as a fallback.
+            make = lease_info.get("Make", "Hyundai")
             model = lease_info.get("Model", "N/A")
             trim = lease_info.get("Trim", "N/A")
 

--- a/lease_calculations.py
+++ b/lease_calculations.py
@@ -21,20 +21,17 @@ def calculate_ccr_full(
     - overflow_down: float — if CCR < 0, this is added as extra cash down
     """
 
-    adjusted_price = selling_price - trade_value
-    M = doc_fee + acq_fee
-    Q = license_fee + title_fee
+    """
+    Cap cost reduction is the total of any customer cash, lease cash,
+    rebates or trade equity that directly lowers the vehicle's capitalized
+    cost. Fees due at signing (doc, acquisition, license and title) are not
+    deducted from this amount so that lease cash always reduces the payment
+    regardless of how it compares to the fees.
+    """
 
-    credits = money_down + lease_cash_used + rebates
+    credits = money_down + lease_cash_used + rebates + trade_value
 
-    # New logic — no longer using tax or base payment here
-    ccr = credits - M - Q
-
-    if ccr >= 0:
-        return round(ccr, 2), 0.0
-    else:
-        overflow = round(abs(ccr), 2)
-        return 0.0, overflow
+    return round(credits, 2), 0.0
 
 def calculate_payment_from_ccr(
     selling_price,


### PR DESCRIPTION
## Summary
- ensure lease cash reduces cap cost
- default vehicle make to Hyundai if missing

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68544eedd9ec83319af39fe3ea164975