### PR TITLE
Fix return unpacking

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -103,7 +103,7 @@ if vin_input:
                     SP = selling_price
                     RES = residual_value
 
-                    ccr, overflow = calculate_ccr_full(
+                    ccr, overflow, _ = calculate_ccr_full(
                         SP=SP,
                         B=B,
                         rebates=0.0,


### PR DESCRIPTION
## Summary
- fix missing variable when unpacking calculate_ccr_full results

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6856d5ab160483319c7b957712f6a22b