### PR TITLE
Fix NameError in payment calculation

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -126,8 +126,7 @@ if vin_input:
                         F=F,
                         τ=τ,
                         M=M,
-                        Q=Q,
-                        ST=debug_ccr.get("Sales Tax", 0.0)  # Pass ST to match TA logic if required
+                        Q=Q
                     )
 
                     st.markdown(f"**Monthly Payment: ${payment['Monthly Payment (MP)']:.2f}**")

--- a/lease_calculations.py
+++ b/lease_calculations.py
@@ -42,7 +42,7 @@ def calculate_ccr_full(SP, B, rebates, TV, K, M, Q, RES, F, W, τ):
         return 0.0, round(abs(CCR), 6), debug_info
     return round(CCR, 6), 0.0, debug_info
 
-def calculate_payment_from_ccr(S, CCR, RES, W, F, τ, M):
+def calculate_payment_from_ccr(S, CCR, RES, W, F, τ, M, Q=0.0):
     cap_cost = S + M
     adjusted_cap_cost = cap_cost - CCR
 
@@ -50,9 +50,9 @@ def calculate_payment_from_ccr(S, CCR, RES, W, F, τ, M):
     rent_charge = F * (adjusted_cap_cost + RES)
     BP =  depreciation + rent_charge
     ST = (BP * τ)* W
-    TA = S+Q+ST+M-CCR
-    AMD = (TA-RES)/W
-    ALC = F * (TA+RES)
+    TA = S + Q + ST + M - CCR
+    AMD = (TA - RES) / W
+    ALC = F * (TA + RES)
     MP = AMD + ALC
 
     return {


### PR DESCRIPTION
## Summary
- fix call to `calculate_payment_from_ccr`
- accept `Q` parameter and compute totals

## Testing
- `python -m py_compile lease_calculations.py lease_app.py setting_page.py`
- `python - <<'EOF'
from lease_calculations import calculate_payment_from_ccr
print(calculate_payment_from_ccr(S=10000, CCR=500, RES=7000, W=36, F=0.0011, τ=0.0725, M=962.5, Q=62.50))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6856e05348f08331858b0dc4a9950e67