### PR TITLE
Fix formatting bug in payment breakdown

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -137,4 +137,7 @@ if vin_input:
                         st.json(debug_ccr)
                         st.markdown("### Payment Breakdown")
                         for k, v in payment.items():
-                            st.markdown(f"**{k}:** ${v:,.2f}")
+                            if isinstance(v, (int, float)):
+                                st.markdown(f"**{k}:** ${v:,.2f}")
+                            else:
+                                st.markdown(f"**{k}:** {v}")


### PR DESCRIPTION
## Summary
- prevent formatting errors when showing payment details

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e158b170833183a2988cf2496eec