### PR TITLE
Fix indentation error in payment loop

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -166,6 +166,6 @@ if vin_input:
                         for k, v in payment.items():
                             if isinstance(v, (int, float)):
                                 st.markdown(f"**{k}:** ${v:,.2f}")
-                                    else:
-                                        st.markdown(f"**{k}:** {v}")
+                            else:
+                                st.markdown(f"**{k}:** {v}")
 


### PR DESCRIPTION
## Summary
- fix unexpected indent around payment breakdown

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6856fc62b2d8833192cd7e788d569cf1