### PR TITLE
Use full county list from CSV in lease selector

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -11,12 +11,20 @@ lease_programs.columns = lease_programs.columns.str.strip()
 vehicle_data = pd.read_excel("Locator_Detail_Updated.xlsx")
 vehicle_data.columns = vehicle_data.columns.str.strip()
 
+# County tax rates
+county_rates_df = pd.read_csv("County_Tax_Rates.csv")
+county_rates_df.columns = county_rates_df.columns.str.strip()
+counties = county_rates_df["County"].tolist()
+tax_rate_lookup = dict(zip(county_rates_df["County"], county_rates_df["Tax Rate"]))
+
 # Sidebar inputs
 with st.sidebar:
     st.header("Lease Parameters")
     vin_input = st.text_input("Enter VIN:", "")
     selected_tier = st.selectbox("Select Tier:", [f"Tier {i}" for i in range(1, 9)])
-    selected_county = st.selectbox("Select County:", ["Adams", "Franklin", "Marion"])
+    selected_county = st.selectbox(
+        "Select County:", counties, index=counties.index("Marion")
+    )
     trade_value = st.number_input("Trade Value ($)", min_value=0.0, value=0.0, step=100.0)
     default_money_down = st.number_input("Default Down Payment ($)", min_value=0.0, value=0.0, step=100.0)
     apply_markup = st.checkbox("Apply Money Factor Markup (+0.0004)", value=False)
@@ -44,7 +52,7 @@ if vin_input:
             st.markdown(f"### Vehicle: {model_year} {make} {model} {trim} — MSRP: ${msrp:,.2f}")
 
             tier_num = int(selected_tier.split(" ")[1])
-            tax_rate = 0.0725
+            tax_rate = tax_rate_lookup.get(selected_county, 7.25) / 100
             mileage_options = [10000, 12000, 15000]
             lease_terms = sorted(lease_matches["Term"].dropna().unique())
 

--- a/setting_page.py
+++ b/setting_page.py
@@ -1,16 +1,17 @@
 import streamlit as st
+import pandas as pd
 
 def show_settings() -> None:
     """Display the settings sidebar and handle reset functionality."""
-    # default values
+    county_rates_df = pd.read_csv("County_Tax_Rates.csv")
+    county_rates_df.columns = county_rates_df.columns.str.strip()
+    counties = county_rates_df["County"].tolist()
+    tax_rates = dict(zip(county_rates_df["County"], county_rates_df["Tax Rate"]))
+
     defaults = {
-        "default_county": "Adams",
-        "counties": [
-            "Adams", "Allen", "Ashland", "Ashtabula", "Athens", # …and all your counties
-        ],
-        "tax_rates": {
-            "Adams": 7.25, "Allen": 6.85, "Ashland": 7.00, # …
-        },
+        "default_county": "Marion",
+        "counties": counties,
+        "tax_rates": tax_rates,
         "money_factors": {
             # (term, mileage): base money factor
             (36, 10000): 0.00256,


### PR DESCRIPTION
## Summary
- load counties from `County_Tax_Rates.csv`
- default the county dropdown to Marion
- use selected county's tax rate when calculating quotes
- load counties from CSV in settings page with Marion default

## Testing
- `python -m py_compile lease_app.py setting_page.py lease_calculations.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e26d4e988331a4e9861bbe366569