### PR TITLE
Fix sidebar county dropdown syntax

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -24,8 +24,10 @@ with st.sidebar:
     selected_tier = st.selectbox("Select Tier:", [f"Tier {i}" for i in range(1, 9)])
 
     selected_county = st.selectbox(
-        "Select County:", counties, index=counties.index("Marion")    
- main
+        "Select County:",
+        counties,
+        index=counties.index("Marion"),
+    )
     trade_value_input = st.number_input("Trade Value ($)", min_value=0.0, value=0.0, step=100.0)
     default_money_down = st.number_input("Default Down Payment ($)", min_value=0.0, value=0.0, step=100.0)
     apply_markup = st.checkbox("Apply Money Factor Markup (+0.0004)", value=False)


### PR DESCRIPTION
## Summary
- fix malformed selectbox call in the sidebar

## Testing
- `pytest -q`
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_685702e0809c8331bfb643f8f24a808b