### PR TITLE
Fix CCR calculation call

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -112,8 +112,14 @@ if vin_input:
                         B=B_total,
                         rebates=0.0,
                         TV=TV_total,
-
-                   
+                        K=K,
+                        M=M,
+                        Q=Q,
+                        RES=RES,
+                        F=F,
+                        W=W,
+                        τ=τ,
+                        adjust_negative=False,
                     )
                     initial_topval = debug_pre.get("Initial TopVal", 0.0)
                     deal_charges = max(0.0, -initial_topval)


### PR DESCRIPTION
## Summary
- fix missing arguments when calculating initial CCR

## Testing
- `python -m py_compile lease_app.py lease_calculations.py setting_page.py`

------
https://chatgpt.com/codex/tasks/task_e_685721a2a58883318db894ace004b98c