### PR TITLE
Show all lease programs per VIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ that restores the original configuration. Global controls include:
 
 - **Default Down Payment**: starting down payment value for each quote.
 - **Apply Money Factor Markup**: toggles a 0.0004 increase to all money factors.
+- **Sale Price**: adjust the selling price when reviewing lease programs.
 
 Each lease term/mileage combination offers an **Incentives** expander where you
 can enter the amount of lease cash to apply (defaults to zero). A **Details**


### PR DESCRIPTION
## Summary
- show all lease programs for a VIN instead of only one term
- allow custom sale price input
- compute quote for each program using new helper
- document the sale price option in README

## Testing
- `python -m py_compile lease_app.py setting_page.py lease_calculations.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685744de7a5083319d12101f40cb5bff