### PR TITLE
Fix default sort value

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -5,7 +5,9 @@ from typing import List, Dict, Tuple, Any
 
 LOGO_PATH = "drivepath_logo.png"
 LOGO_WIDTH = 300
-DEFAULT_SORT_BY = "payment"
+# Default sorting option shown in the sidebar. Must match one of the keys used
+# in utils.sort_quote_options so sorting works without errors.
+DEFAULT_SORT_BY = "Lowest Payment"
 
 
 def render_header(


### PR DESCRIPTION
## Summary
- fix default sort option to match accepted values

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685eda45bb888331b3446659ba0d9b7d