### PR TITLE
Fix sidebar CSS selectors

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -66,11 +66,13 @@ def render_filters_section(quote_options: List[Dict[str, Any]]) -> Tuple[List[in
 
 def render_right_sidebar(quote_options: List[Dict[str, Any]]) -> Tuple[float, float, str, List[int], List[int]]:
     """Render sidebar with trade value, filters, and summary."""
+    st.markdown('<div class="right-sidebar">', unsafe_allow_html=True)
     st.header("Financial Settings")
     with st.expander("Trade & Down Payment", expanded=True):
         trade_value, money_down = render_trade_down_section()
     with st.expander("Filters"):
         term_filter, mileage_filter = render_filters_section(quote_options)
+    st.markdown('</div>', unsafe_allow_html=True)
     sort_by = DEFAULT_SORT_BY  # This could be made user-configurable in the future
     return trade_value, money_down, sort_by, term_filter, mileage_filter
 

--- a/style.py
+++ b/style.py
@@ -36,7 +36,7 @@ div[data-testid="stMultiSelect"] div[data-baseweb="tag"] {
     margin: 0.1rem !important;
 }
 /* Right sidebar styling to match left sidebar */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) {
+.right-sidebar {
     background-color: #f0f2f6 !important;
     padding: 1rem !important;
     border-radius: 0.5rem !important;
@@ -44,39 +44,39 @@ div[data-testid="stHorizontalBlock"] > div:nth-child(2) {
 }
 
 /* Keep expanders transparent with gray background */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stExpander"] {
+.right-sidebar div[data-testid="stExpander"] {
     background-color: transparent !important;
     border: none !important;
     margin-bottom: 0.5rem !important;
 }
 
 /* White backgrounds for all input fields */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) input {
+.right-sidebar input {
     background-color: white !important;
     border: 1px solid #d1d5db !important;
     border-radius: 0.375rem !important;
 }
 
 /* White backgrounds for selectbox */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stSelectbox"] > div {
+.right-sidebar div[data-testid="stSelectbox"] > div {
     background-color: white !important;
     border: 1px solid #d1d5db !important;
 }
 
 /* White backgrounds for multiselect fields */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stMultiSelect"] div[data-baseweb="select"] {
+.right-sidebar div[data-testid="stMultiSelect"] div[data-baseweb="select"] {
     background-color: white !important;
     border: 1px solid #d1d5db !important;
     border-radius: 0.375rem !important;
 }
 
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stMultiSelect"] [role="combobox"] {
+.right-sidebar div[data-testid="stMultiSelect"] [role="combobox"] {
     background-color: white !important;
     border: 1px solid #d1d5db !important;
 }
 
 /* Transparent checkbox (no white box) */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stCheckbox"] {
+.right-sidebar div[data-testid="stCheckbox"] {
     background-color: transparent !important;
     padding: 0 !important;
     border: none !important;
@@ -84,7 +84,7 @@ div[data-testid="stHorizontalBlock"] > div:nth-child(2) div[data-testid="stCheck
 }
 
 /* White backgrounds for buttons */
-div[data-testid="stHorizontalBlock"] > div:nth-child(2) button {
+.right-sidebar button {
     background-color: white !important;
     border: 1px solid #d1d5db !important;
     border-radius: 0.375rem !important;


### PR DESCRIPTION
## Summary
- scope sidebar styling using a `.right-sidebar` class
- wrap the sidebar contents in the new container

## Testing
- `python -m py_compile lease_app.py layout_sections.py style.py utils.py lease_calculations.py data_loader.py update_locator_inventory.py`

------
https://chatgpt.com/codex/tasks/task_e_685edf7a73508331a964cf6c1490665e