### PR TITLE
Update right column styling

### DIFF
--- a/style.py
+++ b/style.py
@@ -90,6 +90,31 @@ div[data-testid="stMultiSelect"] div[data-baseweb="tag"] {
     border-radius: 0.375rem !important;
 }
 
+/* Far right column styling to match sidebar */
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) {
+    background-color: #f0f2f6 !important;
+    padding: 1rem !important;
+    border-radius: 0.5rem !important;
+    border: 1px solid #e1e5e9 !important;
+}
+
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) input,
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) div[data-testid="stSelectbox"] > div,
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) div[data-testid="stMultiSelect"] div[data-baseweb="select"],
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) div[data-testid="stMultiSelect"] [role="combobox"],
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) button {
+    background-color: white !important;
+    border: 1px solid #d1d5db !important;
+    border-radius: 0.375rem !important;
+}
+
+section.main div[data-testid="block-container"] > div[data-testid="stHorizontalBlock"]:first-of-type > div[data-testid="column"]:nth-of-type(2) div[data-testid="stCheckbox"] {
+    background-color: transparent !important;
+    padding: 0 !important;
+    border: none !important;
+    margin: 0.25rem 0 !important;
+}
+
 /* Quote card styling */
 .quote-card,
 .selected-quote {


### PR DESCRIPTION
## Summary
- style far right column to match sidebar background and input fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ee7b310e4833189184c42fc055765