### PR TITLE
Fix closing quote in style.py

### DIFF
--- a/style.py
+++ b/style.py
@@ -168,3 +168,5 @@ div[data-testid="stHorizontalBlock"] {
     margin: 0 !important;
 }
 </style>
+"""
+


### PR DESCRIPTION
## Summary
- fix syntax error in style module so it can be imported

## Testing
- `python - <<'PY'
import style
print('import success', len(style.BASE_CSS))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685f0b191e908331bd66a59a44887691