### PR TITLE
Fix README run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install the required packages from `requirements.txt` and launch Streamlit:
 
 ```bash
 pip install -r requirements.txt
-streamlit run main.py
+streamlit run lease_app.py
 ```
 
 ## Adjusting settings


### PR DESCRIPTION
## Summary
- fix README to reference `lease_app.py`

## Testing
- `pip install -r requirements.txt`
- `streamlit run main.py` *(fails: file not found)*
- `streamlit run lease_app.py` *(runs)*

------
https://chatgpt.com/codex/tasks/task_e_68656a604618833196e9f10c8e1607ee