### PR TITLE
Prevent full-screen video on mobile

### DIFF
--- a/vin_scanner.html
+++ b/vin_scanner.html
@@ -13,7 +13,14 @@
       window.parent.postMessage({ type: "vin", data: decodedText }, "*");
       html5QrCode.stop();
     }
-    html5QrCode.start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess);
+    html5QrCode
+        .start({ facingMode: "environment" }, { fps: 10, qrbox: 250 }, onScanSuccess)
+        .then(() => {
+          const video = document.querySelector('video');
+          if (video) {
+            video.setAttribute('playsinline', 'true');
+          }
+        });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the scanner video stays inline by setting `playsinline`

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d577e6b6483318696c78e87253e40