### PR TITLE
Fix VIN scanner iframe path

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -112,7 +112,20 @@ def render_quote_card(
 def render_vin_scanner_button() -> None:
     """Display a VIN scanning button and embed the camera interface."""
     if st.button("📷 Scan VIN"):
-        components.iframe("vin_scanner.html", height=350, scrolling=False)
+        try:
+            with open("vin_scanner.html", "r", encoding="utf-8") as f:
+                scanner_html = f.read()
+            with open("html5-qrcode.min.js", "r", encoding="utf-8") as js_file:
+                qr_script = js_file.read()
+            scanner_html = scanner_html.replace(
+                '<script src="html5-qrcode.min.js" defer></script>',
+                f"<script>{qr_script}</script>",
+            )
+            components.html(scanner_html, height=350, scrolling=False)
+        except FileNotFoundError:
+            st.error("Camera scanner files not found.")
+            return
+
         st.markdown("_(Scan the barcode on the door or windshield label)_")
         st.markdown(
             """


### PR DESCRIPTION
## Summary
- fix VIN camera interface by embedding vin_scanner.html directly
- inline html5-qrcode script so the camera opens correctly

## Testing
- `python -m py_compile layout_sections.py lease_app.py lease_calculations.py data_loader.py update_locator_inventory.py utils.py style.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686d6e5d2b6883318723c88c300de94a