### PR TITLE
Improve doc for launching Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ pip install -r requirements.txt
 streamlit run lease_app.py
 ```
 
+Do **not** run the file directly with `python lease_app.py`. Session state and
+other features only work when launching the app through the `streamlit` command.
+
 ## Adjusting settings
 
 Financial parameters are configured directly from the sidebar. Available options


### PR DESCRIPTION
## Summary
- clarify that the app must be started with `streamlit run` instead of `python`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686eb4c87ac08331b7de8cda4bfa0e05