### PR TITLE
Fix PDF export functionality

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -3,6 +3,7 @@ from PIL import Image, UnidentifiedImageError
 import pytesseract
 import re
 from utils import calculate_option_payment
+from pdf_utils import generate_quote_pdf
 from typing import List, Dict, Tuple, Any
 from datetime import datetime
 import pandas as pd
@@ -250,8 +251,24 @@ def render_customer_quote_page(
 
     # PDF Export Button (updated below)
     if st.button("Export PDF"):
-        pdf_buffer = generate_pdf_quote(selected_options, tax_rate, base_down, customer_name)
-        st.download_button("Download Quote PDF", pdf_buffer, "lease_quote.pdf", "application/pdf")
+        vehicle_info = {
+            "year": st.session_state.get("model_year", "N/A"),
+            "make": st.session_state.get("make", "N/A"),
+            "model": st.session_state.get("model", "N/A"),
+            "trim": st.session_state.get("trim", "N/A"),
+            "msrp": st.session_state.get("msrp", 0.0),
+            "vin": st.session_state.get("vin", "N/A"),
+        }
+        pdf_buffer = generate_quote_pdf(
+            selected_options,
+            tax_rate,
+            base_down,
+            customer_name,
+            vehicle_info,
+        )
+        st.download_button(
+            "Download Quote PDF", pdf_buffer, "lease_quote.pdf", "application/pdf"
+        )
     
     st.markdown("---")
     st.write("**Disclaimers:** Estimates only. Subject to credit approval, taxes, fees, and final dealer terms. Contact for details.")

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,0 +1,89 @@
+from io import BytesIO
+from datetime import datetime
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+
+from utils import calculate_option_payment
+
+
+def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, vehicle_info):
+    """Return a PDF bytes object summarizing lease options."""
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=letter)
+    width, height = letter
+
+    year = vehicle_info.get("year", "N/A")
+    make = vehicle_info.get("make", "N/A")
+    model = vehicle_info.get("model", "N/A")
+    trim = vehicle_info.get("trim", "N/A")
+    msrp = vehicle_info.get("msrp", 0.0)
+    vin = vehicle_info.get("vin", "N/A")
+
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(1 * inch, height - 1 * inch, "Lease Quote Summary")
+    c.setFont("Helvetica", 10)
+    c.drawString(1 * inch, height - 1.3 * inch, f"Customer: {customer_name}")
+    c.drawString(
+        1 * inch,
+        height - 1.5 * inch,
+        f"Vehicle: {year} {make} {model} {trim} | MSRP: ${msrp:,.2f} | VIN: {vin}",
+    )
+    c.drawString(
+        1 * inch,
+        height - 1.7 * inch,
+        f"Dealership: Mathew's Hyundai | Date: {datetime.today().strftime('%B %d, %Y')}",
+    )
+
+    y = height - 2.2 * inch
+    default_rows = [base_down + 1500 * i for i in range(3)]
+    col_widths = [1.5 * inch] + [2 * inch] * len(selected_options)
+
+    c.drawString(1 * inch, y, "Down Payment")
+    for i, opt in enumerate(selected_options):
+        c.drawCentredString(
+            1 * inch + col_widths[0] + i * col_widths[1] + col_widths[1] / 2,
+            y,
+            f"{opt['term']} Mo | {opt['mileage']:,} mi/yr",
+        )
+    y -= 0.3 * inch
+
+    for default_val in default_rows:
+        down_val = default_val
+        c.drawString(1 * inch, y, f"${down_val:,.2f}")
+        for i, opt in enumerate(selected_options):
+            payment_data = calculate_option_payment(
+                opt['selling_price'],
+                opt['lease_cash_used'],
+                opt['residual_value'],
+                opt['money_factor'],
+                opt['term'],
+                0.0,
+                down_val,
+                tax_rate,
+            )
+            payment = payment_data["payment"]
+            total_cost = payment * opt['term'] + down_val
+            c.drawRightString(
+                1 * inch + col_widths[0] + (i + 1) * col_widths[1] - 0.1 * inch,
+                y,
+                f"${payment:,.2f}/mo (Total: ${total_cost:,.2f})",
+            )
+        y -= 0.3 * inch
+
+    y -= 1 * inch
+    c.drawString(
+        1 * inch, y, "Customer Signature: _______________________________ Date: _______________"
+    )
+
+    y -= 0.5 * inch
+    c.setFont("Helvetica-Oblique", 8)
+    c.drawString(
+        1 * inch,
+        y,
+        "Disclaimers: Estimates only. Subject to credit approval, taxes, fees, and final dealer terms. Contact for details.",
+    )
+
+    c.save()
+    buffer.seek(0)
+    return buffer.getvalue()


### PR DESCRIPTION
## Summary
- create new `pdf_utils` helper for generating PDF quotes
- hook up PDF generation from the customer quote screen
- save vehicle details in `st.session_state` for later export
- remove unused PDF code from `lease_app`

## Testing
- `python -m py_compile lease_app.py layout_sections.py pdf_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff376bdec83318b2f5653388c58bd