### PR TITLE
Fix session state radio selection

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -234,8 +234,8 @@ def render_customer_quote_page(
         options=option_labels,
         key="customer_selected_option",
     )
-    st.session_state['customer_selected_option'] = selected
-    st.markdown(f"**Customer Selected:** {selected}")
+    selection_value = st.session_state.get("customer_selected_option", option_labels[0] if option_labels else "")
+    st.markdown(f"**Customer Selected:** {selection_value}")
 
     # Signature Line (printable)
     st.markdown('<div class="signature-section">', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- avoid direct session_state assignment after radio button in `render_customer_quote_page`

## Testing
- `python -m py_compile layout_sections.py lease_app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ffd779f788331a1eaa21103a5e76b