### PR TITLE
Add printable checkboxes

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -225,17 +225,24 @@ def render_customer_quote_page(
         ])
     )
 
-    option_labels = [
-        f"Option {i + 1}: {opt['term']} Mo | {opt['mileage']:,} mi/yr"
-        for i, opt in enumerate(selected_options)
-    ]
-    selected = st.radio(
-        "\u2705 Select the lease option that works for you:",
-        options=option_labels,
-        key="customer_selected_option",
-    )
-    selection_value = st.session_state.get("customer_selected_option", option_labels[0] if option_labels else "")
-    st.markdown(f"**Customer Selected:** {selection_value}")
+    st.markdown("### Lease Options", unsafe_allow_html=True)
+    for opt in selected_options:
+        payment_data = calculate_option_payment(
+            opt['selling_price'],
+            opt['lease_cash_used'],
+            opt['residual_value'],
+            opt['money_factor'],
+            opt['term'],
+            0.0,
+            base_down,
+            tax_rate,
+        )
+        payment = payment_data["payment"]
+        total_cost = payment * opt['term'] + base_down
+        st.markdown(
+            f"<div style='font-size:16px;padding:4px 0;'>&#x2610; <strong>${base_down:,.2f} Down</strong> — {opt['term']} Mo | {opt['mileage']:,} mi/yr — <strong>${payment:,.2f}/mo</strong> (Total: ${total_cost:,.2f})</div>",
+            unsafe_allow_html=True,
+        )
 
     # Signature Line (printable)
     st.markdown('<div class="signature-section">', unsafe_allow_html=True)

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -71,7 +71,28 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
             )
         y -= 0.3 * inch
 
-    y -= 1 * inch
+    y -= 0.5 * inch
+    for opt in selected_options:
+        payment_data = calculate_option_payment(
+            opt['selling_price'],
+            opt['lease_cash_used'],
+            opt['residual_value'],
+            opt['money_factor'],
+            opt['term'],
+            0.0,
+            base_down,
+            tax_rate,
+        )
+        payment = payment_data["payment"]
+        total_cost = payment * opt['term'] + base_down
+        c.drawString(
+            1 * inch,
+            y,
+            f"\u2610 ${base_down:,.2f} Down \u2014 {opt['term']} Mo | {opt['mileage']:,} mi/yr \u2014 ${payment:,.2f}/mo (Total: ${total_cost:,.2f})",
+        )
+        y -= 0.25 * inch
+
+    y -= 0.5 * inch
     c.drawString(
         1 * inch, y, "Customer Signature: _______________________________ Date: _______________"
     )


### PR DESCRIPTION
## Summary
- show static checkboxes for each option on the customer quote page
- include same checkboxes in generated PDF so customers can mark their selection by hand

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687002b58214833198d9116b4123652c