### PR TITLE
Switch from pdfkit to WeasyPrint

### DIFF
--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-import pdfkit
+from weasyprint import HTML
 from utils import calculate_option_payment
 
 
@@ -85,5 +85,4 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
     </html>
     """
 
-    config = pdfkit.configuration(wkhtmltopdf=os.getenv("WKHTMLTOPDF_BINARY", "/usr/bin/wkhtmltopdf"))
-    return pdfkit.from_string(html_content, False, configuration=config, options={"enable-local-file-access": ""})
+    return HTML(string=html_content, base_url=os.getcwd()).write_pdf()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pillow
 pytesseract
 reportlab
 streamlit-drawable-canvas  # New: For e-signature pad
-pdfkit
+weasyprint==65.1


### PR DESCRIPTION
## Summary
- switch PDF generation to WeasyPrint
- update requirements to include `weasyprint` instead of `pdfkit`

## Testing
- `python -m py_compile lease_app.py lease_calculations.py data_loader.py layout_sections.py pdf_utils.py style.py update_locator_inventory.py utils.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687160cd65188331a9dd2888daf62586