### PR TITLE
Handle missing WeasyPrint system deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ pip install -r requirements.txt
 streamlit run lease_app.py
 ```
 
+### System packages for PDF generation
+
+`pdf_utils.py` uses [WeasyPrint](https://weasyprint.org/) which depends on
+native libraries like cairo and pango. Install these packages on Debian/Ubuntu
+systems before running the app:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+    libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+```
+
 Do **not** run the file directly with `python lease_app.py`. Session state and
 other features only work when launching the app through the `streamlit` command.
 

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,6 +1,11 @@
 import os
 from datetime import datetime
-from weasyprint import HTML
+try:
+    from weasyprint import HTML
+    _WEASYPRINT_AVAILABLE = True
+except Exception as exc:  # ImportError or OSError when native libs are missing
+    _WEASYPRINT_AVAILABLE = False
+    _WEASYPRINT_ERROR = exc
 from utils import calculate_option_payment
 
 
@@ -84,5 +89,10 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
     </body>
     </html>
     """
+    if not _WEASYPRINT_AVAILABLE:
+        raise RuntimeError(
+            "WeasyPrint is not available. Install cairo, pango and gdk-pixbuf system packages to enable PDF generation. "
+            f"Original error: {_WEASYPRINT_ERROR}"
+        )
 
     return HTML(string=html_content, base_url=os.getcwd()).write_pdf()


### PR DESCRIPTION
## Summary
- handle failure to import WeasyPrint at runtime
- guide users to install required OS packages for WeasyPrint

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871668bc26c83319639a694b45e5c9b