### PR TITLE
Add automatic install of WeasyPrint deps

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       "version": "3.10"
     }
   },
-  "postCreateCommand": "pip install -r requirements.txt",
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info && pip install -r requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
     libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
 ```
 
+If you open the project in the included **devcontainer**, these packages are
+installed automatically when the container is created.
+
 Do **not** run the file directly with `python lease_app.py`. Session state and
 other features only work when launching the app through the `streamlit` command.
 


### PR DESCRIPTION
## Summary
- install system packages for WeasyPrint in the devcontainer
- document that the devcontainer installs them automatically

## Testing
- `python -m py_compile lease_app.py layout_sections.py pdf_utils.py lease_calculations.py data_loader.py utils.py update_locator_inventory.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6871731c3414833186aeb9932114100e