### PR TITLE
Improve WeasyPrint setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ streamlit run lease_app.py
 ### System packages for PDF generation
 
 `pdf_utils.py` uses [WeasyPrint](https://weasyprint.org/) which depends on
-native libraries like cairo and pango. Install these packages on Debian/Ubuntu
-systems before running the app:
+native libraries like cairo and pango. First install the Python package, then the
+system libraries on Debian/Ubuntu systems:
 
 ```bash
+pip install weasyprint
 sudo apt-get update
 sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
     libgdk-pixbuf2.0-0 libffi-dev shared-mime-info

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -94,7 +94,8 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
     """
     if not _WEASYPRINT_AVAILABLE:
         raise RuntimeError(
-            "WeasyPrint is not available. Install cairo, pango and gdk-pixbuf system packages to enable PDF generation. "
+            "WeasyPrint is not available. Install the `weasyprint` Python package "
+            "and the cairo, pango and gdk-pixbuf system libraries to enable PDF generation. "
             f"Original error: {_WEASYPRINT_ERROR}"
         )
 


### PR DESCRIPTION
## Summary
- tweak pdf generation error when WeasyPrint is missing
- document installing the `weasyprint` package in the setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769413d2988331942e24c2ead5b9d6