### PR TITLE
Fix WeasyPrint dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
     libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info
 ```
 
+On other Linux distributions, install the equivalent packages using your
+system's package manager. After installing the native libraries you can
+confirm WeasyPrint is working by running:
+
+```bash
+python -c "from weasyprint import HTML; print('WeasyPrint loaded')"
+```
+
 If you open the project in the included **devcontainer**, these packages are
 installed automatically when the container is created.
 


### PR DESCRIPTION
## Summary
- update README with a verification step for WeasyPrint and note about installing packages on other distros

## Testing
- `python -m py_compile lease_app.py pdf_utils.py app.py data_loader.py utils.py lease_calculations.py style.py update_locator_inventory.py layout_sections.py`

------
https://chatgpt.com/codex/tasks/task_e_6876987b2f348331b7166fcf054ea8c4