### PR TITLE
Clarify WeasyPrint install instructions

### DIFF
--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -96,6 +96,9 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
         raise RuntimeError(
             "WeasyPrint is not available. Install the `weasyprint` Python package "
             "and the cairo, pango and gdk-pixbuf system libraries to enable PDF generation. "
+            "On Debian/Ubuntu run: `sudo apt-get update && sudo apt-get install -y "
+            "libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 "
+            "libffi-dev shared-mime-info`. "
             f"Original error: {_WEASYPRINT_ERROR}"
         )
 


### PR DESCRIPTION
## Summary
- make WeasyPrint error message explicitly mention the apt-get command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68769c6598e88331958e61827378d4d5