### PR TITLE
Add markup toggle for lease quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ other features only work when launching the app through the `streamlit` command.
 ## Adjusting settings
 
 Financial parameters are configured directly from the sidebar. Available options
-include entering a trade‑in value, specifying customer cash down and toggling a
-money factor markup. Sorting and filtering controls allow you to refine quote
-options by term or mileage.
+include entering a trade‑in value, specifying customer cash down and toggling
+the 0.0004 money factor markup. Sorting and filtering controls allow you to
+refine quote options by term or mileage.
 
 Each lease term and mileage combination provides an **Incentives** expander
 for lease cash input (defaults to zero). A **Details** expander displays the

--- a/layout_sections.py
+++ b/layout_sections.py
@@ -58,7 +58,7 @@ def render_filters_section(
 
 def render_right_sidebar(
     quote_options: List[Dict[str, Any]]
-) -> Tuple[float, float, str, List[int], List[int], bool]:
+) -> Tuple[float, float, str, List[int], List[int], bool, bool]:
     st.markdown('<div class="right-sidebar">', unsafe_allow_html=True)
     st.header("Financial Settings")
     with st.expander("Trade & Down Payment", expanded=True):
@@ -66,6 +66,12 @@ def render_right_sidebar(
         create_quote_clicked = st.button("Create Customer Quote")
     with st.expander("Filters"):
         term_filter, mileage_filter = render_filters_section(quote_options)
+    with st.expander("Markup", expanded=True):
+        apply_markup = st.checkbox(
+            "Add 0.0004 Money Factor Markup",
+            value=st.session_state.get("apply_markup", True),
+        )
+    st.session_state.apply_markup = apply_markup
     st.markdown("</div>", unsafe_allow_html=True)
     sort_by = DEFAULT_SORT_BY
     return (
@@ -75,6 +81,7 @@ def render_right_sidebar(
         term_filter,
         mileage_filter,
         create_quote_clicked,
+        apply_markup,
     )
 
 

--- a/lease_app.py
+++ b/lease_app.py
@@ -25,6 +25,8 @@ def main() -> None:
         st.session_state.page = 'quote'
     if 'selected_down_payment' not in st.session_state:
         st.session_state.selected_down_payment = 0.0
+    if 'apply_markup' not in st.session_state:
+        st.session_state.apply_markup = True
 
     with st.spinner("Loading data..."):
         try:
@@ -205,7 +207,16 @@ def main() -> None:
     main_col, right_col = st.columns([2.5, 1], gap="large")
 
     with right_col:
-        trade_value, default_money_down, sort_by, term_filter, mileage_filter, create_quote_clicked = render_right_sidebar(quote_options)
+        (
+            trade_value,
+            default_money_down,
+            sort_by,
+            term_filter,
+            mileage_filter,
+            create_quote_clicked,
+            apply_markup,
+        ) = render_right_sidebar(quote_options)
+        st.session_state.apply_markup = apply_markup
         if create_quote_clicked:
             st.session_state.selected_down_payment = default_money_down
             st.session_state.page = 'print'


### PR DESCRIPTION
## Summary
- add `apply_markup` session state and markups expander
- surface markup checkbox in the UI
- document 0.0004 markup behavior

## Testing
- `python -m py_compile lease_app.py layout_sections.py`


------
https://chatgpt.com/codex/tasks/task_e_687924dea49083318a22ad2c4d8c027e