### PR TITLE
Improve PDF export flow

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -342,30 +342,29 @@ def render_customer_quote_page(
 
     st.markdown("</div>", unsafe_allow_html=True)
 
-    # PDF Export Button (updated below)
-    if st.button("Export PDF", key="export_pdf_main"):
-        vehicle_info = {
-            "year": st.session_state.get("model_year", "N/A"),
-            "make": st.session_state.get("make", "N/A"),
-            "model": st.session_state.get("model", "N/A"),
-            "trim": st.session_state.get("trim", "N/A"),
-            "msrp": st.session_state.get("msrp", 0.0),
-            "vin": st.session_state.get("vin", "N/A"),
-        }
-        try:
-            pdf_buffer = generate_quote_pdf(
-                selected_options,
-                tax_rate,
-                base_down,
-                customer_name,
-                vehicle_info,
-            )
-        except RuntimeError as e:
-            st.error(str(e))
-        else:
-            st.download_button(
-                "Download Quote PDF",
-                pdf_buffer,
-                "lease_quote.pdf",
-                "application/pdf",
-            )
+    vehicle_info = {
+        "year": st.session_state.get("model_year", "N/A"),
+        "make": st.session_state.get("make", "N/A"),
+        "model": st.session_state.get("model", "N/A"),
+        "trim": st.session_state.get("trim", "N/A"),
+        "msrp": st.session_state.get("msrp", 0.0),
+        "vin": st.session_state.get("vin", "N/A"),
+    }
+    try:
+        pdf_buffer = generate_quote_pdf(
+            selected_options,
+            tax_rate,
+            base_down,
+            customer_name,
+            vehicle_info,
+        )
+    except RuntimeError as e:
+        st.error(str(e))
+    else:
+        st.download_button(
+            "Download Quote PDF",
+            pdf_buffer,
+            "lease_quote.pdf",
+            "application/pdf",
+            key="export_pdf_main",
+        )

--- a/lease_app.py
+++ b/lease_app.py
@@ -178,29 +178,28 @@ def main() -> None:
             st.session_state.get('selected_down_payment',
                                 st.session_state.get('default_money_down', 0.0)),
         )
-        # New: PDF Export
-        if st.button("Export PDF", key="export_pdf_button"):
-            vehicle_info = {
-                "year": st.session_state.get("model_year", "N/A"),
-                "make": st.session_state.get("make", "N/A"),
-                "model": st.session_state.get("model", "N/A"),
-                "trim": st.session_state.get("trim", "N/A"),
-                "msrp": st.session_state.get("msrp", 0.0),
-                "vin": st.session_state.get("vin", "N/A"),
-            }
-            pdf_buffer = generate_quote_pdf(
-                selected,
-                tax_rate,
-                st.session_state.selected_down_payment,
-                customer_name,
-                vehicle_info,
-            )
-            st.download_button(
-                "Download Quote PDF",
-                pdf_buffer,
-                "lease_quote.pdf",
-                "application/pdf",
-            )
+        vehicle_info = {
+            "year": st.session_state.get("model_year", "N/A"),
+            "make": st.session_state.get("make", "N/A"),
+            "model": st.session_state.get("model", "N/A"),
+            "trim": st.session_state.get("trim", "N/A"),
+            "msrp": st.session_state.get("msrp", 0.0),
+            "vin": st.session_state.get("vin", "N/A"),
+        }
+        pdf_buffer = generate_quote_pdf(
+            selected,
+            tax_rate,
+            st.session_state.selected_down_payment,
+            customer_name,
+            vehicle_info,
+        )
+        st.download_button(
+            "Download Quote PDF",
+            pdf_buffer,
+            "lease_quote.pdf",
+            "application/pdf",
+            key="export_pdf_button",
+        )
         return
 
     # Layout columns


### PR DESCRIPTION
## Summary
- simplify PDF export buttons so downloading is a single step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879272b0dcc833185d495d88f4cfa39