### PR TITLE
Remove redundant export PDF button

### DIFF
--- a/lease_app.py
+++ b/lease_app.py
@@ -178,28 +178,6 @@ def main() -> None:
             st.session_state.get('selected_down_payment',
                                 st.session_state.get('default_money_down', 0.0)),
         )
-        vehicle_info = {
-            "year": st.session_state.get("model_year", "N/A"),
-            "make": st.session_state.get("make", "N/A"),
-            "model": st.session_state.get("model", "N/A"),
-            "trim": st.session_state.get("trim", "N/A"),
-            "msrp": st.session_state.get("msrp", 0.0),
-            "vin": st.session_state.get("vin", "N/A"),
-        }
-        pdf_buffer = generate_quote_pdf(
-            selected,
-            tax_rate,
-            st.session_state.selected_down_payment,
-            customer_name,
-            vehicle_info,
-        )
-        st.download_button(
-            "Download Quote PDF",
-            pdf_buffer,
-            "lease_quote.pdf",
-            "application/pdf",
-            key="export_pdf_button",
-        )
         return
 
     # Layout columns


### PR DESCRIPTION
## Summary
- remove extra export logic in `lease_app`

## Testing
- `python -m py_compile lease_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68792bd97d188331ace20f290e8bd4d7