### PR TITLE
Add checkboxes to quote PDF

### DIFF
--- a/layout_sections.py
+++ b/layout_sections.py
@@ -232,13 +232,6 @@ def render_customer_quote_page(
             vertical-align: middle;
         }
 
-        /* Add checkboxes using pseudo-elements */
-        .checkbox-cell::before {
-            content: "☐ ";
-            font-size: 16px;
-            margin-right: 4px;
-            vertical-align: middle;
-        }
 
         /* Print-friendly rules */
         @media print {
@@ -320,7 +313,7 @@ def render_customer_quote_page(
                 tax_rate,
             )
             payment = payment_data["payment"]
-            body_html += f'<td class="checkbox-cell">${payment:,.2f}/mo</td>'
+            body_html += f'<td>☐ ${payment:,.2f}/mo</td>'
         body_html += "</tr>"
 
     footer_html = "</table>"

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -49,7 +49,7 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
                 tax_rate,
             )
             payment = payment_data['payment']
-            body_html += f"<td class=\"checkbox-cell\">${payment:,.2f}/mo</td>"
+            body_html += f"<td>☐ ${payment:,.2f}/mo</td>"
         body_html += "</tr>"
 
     footer_html = "</table>"
@@ -77,12 +77,6 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
         }}
         .lease-table td {{
             padding: 10px;
-            vertical-align: middle;
-        }}
-        .checkbox-cell::before {{
-            content: '☐ ';
-            font-size: 16px;
-            margin-right: 4px;
             vertical-align: middle;
         }}
         </style>
@@ -146,7 +140,7 @@ def generate_quote_pdf(selected_options, tax_rate, base_down, customer_name, veh
                 tax_rate,
             )
             payment = payment_data['payment']
-            row.append(f"${payment:,.2f}/mo")
+            row.append(f"☐ ${payment:,.2f}/mo")
         table_data.append(row)
 
     table = Table(table_data, hAlign="LEFT")


### PR DESCRIPTION
## Summary
- include a visible `☐` prefix in payment cells when generating the PDF
- remove unused checkbox CSS
- update the customer quote page to show the checkbox character directly

## Testing
- `python -m py_compile pdf_utils.py layout_sections.py`

------
https://chatgpt.com/codex/tasks/task_e_68792ebeed8883319d389bf8ca8111c0